### PR TITLE
Fix #277 - FullDetailsView - Facets editor takes full page width and breaks UI

### DIFF
--- a/src/components/FacetsEditor/FacetsEditor.js
+++ b/src/components/FacetsEditor/FacetsEditor.js
@@ -3,7 +3,7 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Col, Grid, Row } from 'react-bootstrap'
+import { Col, Row } from 'react-bootstrap'
 import Contribution from '../../utils/contribution'
 import GlobsPicker from '../GlobsPicker'
 
@@ -25,13 +25,13 @@ class FacetsEditor extends Component {
     const { onChange, component, previewDefinition, readOnly } = this.props
 
     return (
-      <Grid className="no-gutters">
+      <div>
         {facets.map(item => (
           <Row key={item}>
-            <Col md={1}>
+            <Col md={3}>
               <span>{item}</span>
             </Col>
-            <Col md={11}>
+            <Col md={9}>
               <GlobsPicker
                 readOnly={readOnly}
                 className={Contribution.classIfDifferent(
@@ -46,7 +46,7 @@ class FacetsEditor extends Component {
             </Col>
           </Row>
         ))}
-      </Grid>
+      </div>
     )
   }
 }

--- a/src/components/PageDefinitions.js
+++ b/src/components/PageDefinitions.js
@@ -68,7 +68,7 @@ class PageDefinitions extends AbstractPageDefinitions {
             }}
           >
             Refresh
-          </AntdButton>
+          </AntdButton>{' '}
           <AntdButton type="secondary" size="small" onClick={() => notification.close(key)}>
             Dismiss
           </AntdButton>
@@ -76,7 +76,7 @@ class PageDefinitions extends AbstractPageDefinitions {
       )
       notification.open({
         message: 'Unsaved Changes',
-        description: 'Some information have been changed and are currently unsaved. Are you sure to continue?',
+        description: 'Some information has been changed and is currently unsaved. Are you sure to continue?',
         btn: NotificationButtons,
         key,
         onClose: notification.close(key),

--- a/src/styles/_FacetsEditor.scss
+++ b/src/styles/_FacetsEditor.scss
@@ -1,8 +1,3 @@
-.container.no-gutters {
-  padding-left: 0;
-  padding-right: 0;
-}
-
 .facets--isEdited,
 .isDifferent {
   background: red !important;


### PR DESCRIPTION
Also:
- improved the English text in the notification message and
- added a white space between the buttons _Refresh_ and _Dismiss_ in the same notification