### PR TITLE
Fix #294 (CI) - I can't see all the attributions

### DIFF
--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -17,7 +17,8 @@ class CopyrightsRenderer extends Component {
   static defaultProps = {
     readOnly: false,
     container: null,
-    classIfDifferent: ''
+    classIfDifferent: '',
+    placement: 'left'
   }
 
   state = {
@@ -67,7 +68,7 @@ class CopyrightsRenderer extends Component {
         trigger="click"
         rootClose={readOnly || !hasChanges} // hide overlay when the user clicks outside the overlay
         container={container}
-        placement="left"
+        placement={placement}
         overlay={
           <PopoverRenderer
             addItem={this.addItem}
@@ -107,7 +108,8 @@ CopyrightsRenderer.propTypes = {
   onSave: PropTypes.func,
   readOnly: PropTypes.bool,
   container: PropTypes.instanceOf(Element),
-  classIfDifferent: PropTypes.string
+  classIfDifferent: PropTypes.string,
+  placement: PropTypes.string
 }
 
 export default CopyrightsRenderer

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import isNumber from 'lodash/isNumber'
 import { OverlayTrigger } from 'react-bootstrap'
@@ -88,10 +88,10 @@ class CopyrightsRenderer extends Component {
           />
         }
       >
-        <div>
+        <Fragment>
           {!readOnly && <i className="fas fa-pencil-alt editable-marker" />}
           <span className={`copyrightVal ${classIfDifferent}`}>{values && values[0] ? values[0].value : null}</span>
-        </div>
+        </Fragment>
       </OverlayTrigger>
     )
   }

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -24,11 +24,11 @@ class CopyrightsRenderer extends Component {
     currentItem: null,
     hasChanges: false,
     showAddRow: false,
-    values: null
+    values: []
   }
 
   componentDidMount() {
-    this.setState({ values: this.props.item.value })
+    this.props.item.value && this.setState({ values: this.props.item.value })
   }
 
   onShowAddRow = () => {
@@ -57,10 +57,10 @@ class CopyrightsRenderer extends Component {
   onSave = () => this.props.onSave(this.state.values.map(item => item.value))
 
   render() {
-    const { readOnly, container, classIfDifferent } = this.props
+    const { readOnly, container, classIfDifferent, placement } = this.props
     const { hasChanges, values, showAddRow } = this.state
 
-    if (!values) return null
+    if (!values.length && readOnly) return null
 
     return (
       <OverlayTrigger
@@ -87,7 +87,10 @@ class CopyrightsRenderer extends Component {
           />
         }
       >
-        <div className={`copyrightVal ${classIfDifferent}`}>{values && values[0] ? values[0].value : null}</div>
+        <div>
+          {!readOnly && <i className="fas fa-pencil-alt editable-marker" />}
+          <span className={`copyrightVal ${classIfDifferent}`}>{values && values[0] ? values[0].value : null}</span>
+        </div>
       </OverlayTrigger>
     )
   }

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isNumber from 'lodash/isNumber'
 import { OverlayTrigger } from 'react-bootstrap'
@@ -88,10 +88,10 @@ class CopyrightsRenderer extends Component {
           />
         }
       >
-        <Fragment>
+        <div className="copyrightContainer">
           {!readOnly && <i className="fas fa-pencil-alt editable-marker" />}
-          <span className={`copyrightVal ${classIfDifferent}`}>{values && values[0] ? values[0].value : null}</span>
-        </Fragment>
+          <span className={classIfDifferent}>{values && values[0] ? values[0].value : null}</span>
+        </div>
       </OverlayTrigger>
     )
   }

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -33,10 +33,6 @@ class CopyrightsRenderer extends Component {
     this.props.item.value && this.setState({ values: this.props.item.value })
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return !isEqual(nextProps.item.value, this.state.values)
-  }
-
   onShowAddRow = () => {
     this.setState({ showAddRow: true, currentItem: null })
   }

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -15,7 +15,8 @@ import PopoverRenderer from './PopoverRenderer'
  */
 class CopyrightsRenderer extends Component {
   static defaultProps = {
-    readOnly: false
+    readOnly: false,
+    container: null
   }
 
   state = {
@@ -55,7 +56,7 @@ class CopyrightsRenderer extends Component {
   onSave = () => this.props.onSave(this.state.values.map(item => item.value))
 
   render() {
-    const { readOnly } = this.props
+    const { readOnly, container } = this.props
     const { hasChanges, values, showAddRow } = this.state
 
     if (!values) return null
@@ -65,7 +66,7 @@ class CopyrightsRenderer extends Component {
         <OverlayTrigger
           trigger="click"
           rootClose={readOnly || !hasChanges} // hide overlay when the user clicks outside the overlay
-          container={document.getElementsByClassName('ReactTable')[0]}
+          container={container}
           placement="left"
           overlay={
             <PopoverRenderer
@@ -101,8 +102,9 @@ CopyrightsRenderer.propTypes = {
     value: PropTypes.array
   }).isRequired,
 
-  onSave: PropTypes.func.isRequired,
-  readOnly: PropTypes.bool
+  onSave: PropTypes.func,
+  readOnly: PropTypes.bool,
+  container: PropTypes.instanceOf(Element)
 }
 
 export default CopyrightsRenderer

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -16,7 +16,8 @@ import PopoverRenderer from './PopoverRenderer'
 class CopyrightsRenderer extends Component {
   static defaultProps = {
     readOnly: false,
-    container: null
+    container: null,
+    classIfDifferent: ''
   }
 
   state = {
@@ -56,7 +57,7 @@ class CopyrightsRenderer extends Component {
   onSave = () => this.props.onSave(this.state.values.map(item => item.value))
 
   render() {
-    const { readOnly, container } = this.props
+    const { readOnly, container, classIfDifferent } = this.props
     const { hasChanges, values, showAddRow } = this.state
 
     if (!values) return null
@@ -87,7 +88,7 @@ class CopyrightsRenderer extends Component {
             />
           }
         >
-          <div>{values && values[0] ? values[0].value : null}</div>
+          <div className={classIfDifferent}>{values && values[0] ? values[0].value : null}</div>
         </OverlayTrigger>
       </div>
     )
@@ -104,7 +105,8 @@ CopyrightsRenderer.propTypes = {
 
   onSave: PropTypes.func,
   readOnly: PropTypes.bool,
-  container: PropTypes.instanceOf(Element)
+  container: PropTypes.instanceOf(Element),
+  classIfDifferent: PropTypes.string
 }
 
 export default CopyrightsRenderer

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -4,6 +4,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isNumber from 'lodash/isNumber'
+import isEqual from 'lodash/isEqual'
 import { OverlayTrigger } from 'react-bootstrap'
 
 import PopoverRenderer from './PopoverRenderer'
@@ -30,6 +31,10 @@ class CopyrightsRenderer extends Component {
 
   componentDidMount() {
     this.props.item.value && this.setState({ values: this.props.item.value })
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return !isEqual(nextProps.item.value, this.state.values)
   }
 
   onShowAddRow = () => {

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -63,34 +63,32 @@ class CopyrightsRenderer extends Component {
     if (!values) return null
 
     return (
-      <div>
-        <OverlayTrigger
-          trigger="click"
-          rootClose={readOnly || !hasChanges} // hide overlay when the user clicks outside the overlay
-          container={container}
-          placement="left"
-          overlay={
-            <PopoverRenderer
-              addItem={this.addItem}
-              canAddItems={!readOnly}
-              deleteRow={this.deleteRow}
-              editable={!readOnly}
-              editorPlaceHolder={'Copyright'}
-              editorType={'text'}
-              editRow={this.editRow}
-              hasChanges={hasChanges}
-              onSave={this.onSave}
-              onShowAddRow={this.onShowAddRow}
-              showAddRow={showAddRow}
-              title={'Copyrights'}
-              undoEdit={this.undoEdit}
-              values={values}
-            />
-          }
-        >
-          <div className={classIfDifferent}>{values && values[0] ? values[0].value : null}</div>
-        </OverlayTrigger>
-      </div>
+      <OverlayTrigger
+        trigger="click"
+        rootClose={readOnly || !hasChanges} // hide overlay when the user clicks outside the overlay
+        container={container}
+        placement="left"
+        overlay={
+          <PopoverRenderer
+            addItem={this.addItem}
+            canAddItems={!readOnly}
+            deleteRow={this.deleteRow}
+            editable={!readOnly}
+            editorPlaceHolder={'Copyright'}
+            editorType={'text'}
+            editRow={this.editRow}
+            hasChanges={hasChanges}
+            onSave={this.onSave}
+            onShowAddRow={this.onShowAddRow}
+            showAddRow={showAddRow}
+            title={'Copyrights'}
+            undoEdit={this.undoEdit}
+            values={values}
+          />
+        }
+      >
+        <div className={`copyrightVal ${classIfDifferent}`}>{values && values[0] ? values[0].value : null}</div>
+      </OverlayTrigger>
     )
   }
 }

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -13,6 +13,7 @@ import gem from '../images/gem.png'
 import nuget from '../images/nuget.svg'
 import moment from 'moment'
 import Contribution from '../utils/contribution'
+import CopyrightsRenderer from './CopyrightsRenderer'
 
 export default class DefinitionEntry extends React.Component {
   static propTypes = {
@@ -367,12 +368,11 @@ export default class DefinitionEntry extends React.Component {
           <Row>
             <Col md={2}>{this.renderLabel('Attribution', true)}</Col>
             <Col md={10} className="definition__line">
-              {this.renderWithToolTipIfDifferent(
-                'licensed.attribution.parties',
-                <p className={`list-singleLine ${this.classIfDifferent('licensed.attribution.parties')}`}>
-                  {get(licensed, 'attribution.parties', []).join(', ')}
-                </p>
-              )}
+              <CopyrightsRenderer
+                item={{ value: get(licensed, 'attribution.parties', []).map(l => ({ value: l })) }}
+                readOnly
+                classIfDifferent={'bg-info'}
+              />
             </Col>
           </Row>
           <Row>

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -357,12 +357,11 @@ export default class DefinitionEntry extends React.Component {
           <Row>
             <Col md={2}>{this.renderLabel('Discovered')}</Col>
             <Col md={10} className="definition__line">
-              {this.renderWithToolTipIfDifferent(
-                'discovered.expressions',
-                <p className={`list-singleLine ${this.classIfDifferent('licensed.discovered.expressions')}`}>
-                  {get(licensed, 'discovered.expressions', []).join(', ')}
-                </p>
-              )}
+              <CopyrightsRenderer
+                item={{ value: get(licensed, 'discovered.expressions', []).map(l => ({ value: l })) }}
+                readOnly
+                classIfDifferent={this.classIfDifferent('licensed.discovered.expressions')}
+              />
             </Col>
           </Row>
           <Row>

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -371,7 +371,7 @@ export default class DefinitionEntry extends React.Component {
               <CopyrightsRenderer
                 item={{ value: get(licensed, 'attribution.parties', []).map(l => ({ value: l })) }}
                 readOnly
-                classIfDifferent={'bg-info'}
+                classIfDifferent={this.classIfDifferent('licensed.attribution.parties')}
               />
             </Col>
           </Row>

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -4,7 +4,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { TwoLineEntry, InlineEditor } from './'
-import { Row, Col, OverlayTrigger, Tooltip } from 'react-bootstrap'
+import { Row, Col, OverlayTrigger, Tooltip, Popover } from 'react-bootstrap'
 import { get, isEqual, union } from 'lodash'
 import github from '../images/GitHub-Mark-120px-plus.png'
 import npm from '../images/n-large.png'
@@ -357,21 +357,13 @@ export default class DefinitionEntry extends React.Component {
           <Row>
             <Col md={2}>{this.renderLabel('Discovered')}</Col>
             <Col md={10} className="definition__line">
-              <CopyrightsRenderer
-                item={{ value: get(licensed, 'discovered.expressions', []).map(l => ({ value: l })) }}
-                readOnly
-                classIfDifferent={this.classIfDifferent('licensed.discovered.expressions')}
-              />
+              {this.renderPopover(licensed, 'discovered.expressions', 'Discovered')}
             </Col>
           </Row>
           <Row>
             <Col md={2}>{this.renderLabel('Attribution', true)}</Col>
             <Col md={10} className="definition__line">
-              <CopyrightsRenderer
-                item={{ value: get(licensed, 'attribution.parties', []).map(l => ({ value: l })) }}
-                readOnly
-                classIfDifferent={this.classIfDifferent('licensed.attribution.parties')}
-              />
+              {this.renderPopover(licensed, 'attribution.parties', 'Attributions')}
             </Col>
           </Row>
           <Row>
@@ -386,6 +378,33 @@ export default class DefinitionEntry extends React.Component {
           </Row>
         </Col>
       </Row>
+    )
+  }
+
+  renderPopover(licensed, key, title) {
+    const attributions = get(licensed, key, [])
+    if (!attributions) return null
+
+    return (
+      <OverlayTrigger
+        trigger="click"
+        placement="left"
+        overlay={
+          <Popover title={title}>
+            <div className="popoverRenderer popoverRenderer_scrollY">
+              {attributions.map((a, index) => (
+                <div key={`${a}_${index}`} className="popoverRenderer__items">
+                  <div className="popoverRenderer__items__value">
+                    <span>{a}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Popover>
+        }
+      >
+        <span className="popoverSpan">{attributions}</span>
+      </OverlayTrigger>
     )
   }
 

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -164,9 +164,9 @@ export default class FileList extends Component {
         resizable: false,
         Cell: row => (
           <CopyrightsRenderer
+            container={document.getElementsByClassName('ReactTable')[0]}
             item={row}
             readOnly={readOnly}
-            showPopup={this.showPopup}
             onSave={value => {
               this.props.onChange(`files[${row.original.id}]`, value, null, value => {
                 return {

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -207,7 +207,6 @@ export default class FileList extends Component {
     const { files, isFiltering } = this.state
 
     return (
-      <div>
         <TreeTable
           showPagination={false}
           sortable={false}
@@ -230,7 +229,6 @@ export default class FileList extends Component {
             )
           }}
         />
-      </div>
     )
   }
 }

--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -14,6 +14,7 @@ import FileList from '../FileList'
 import InlineEditor from '../InlineEditor'
 import MonacoEditorWrapper from '../MonacoEditorWrapper'
 import FacetsEditor from '../FacetsEditor'
+import CopyrightsRenderer from '../CopyrightsRenderer'
 import 'antd/dist/antd.css'
 import Contribution from '../../utils/contribution'
 import Definition from '../../utils/definition'
@@ -211,15 +212,10 @@ class FullDetailComponent extends Component {
           <Row className="no-gutters">
             <Col md={3}>{this.renderLabel('Attribution')}</Col>
             <Col md={9} className="definition__line">
-              <p
-                className={`list-singleLine ${Contribution.classIfDifferent(
-                  definition,
-                  previewDefinition,
-                  'licensed.attribution.parties'
-                )}`}
-              >
-                {get(licensed, 'attribution.parties', []).join(', ')}
-              </p>
+              <CopyrightsRenderer
+                item={{ value: get(licensed, 'attribution.parties', []).map(l => ({ value: l })) }}
+                readOnly
+              />
             </Col>
           </Row>
           <Row className="no-gutters">

--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -213,6 +213,7 @@ class FullDetailComponent extends Component {
             <Col md={3}>{this.renderLabel('Attribution')}</Col>
             <Col md={9} className="definition__line">
               <CopyrightsRenderer
+                container={document.getElementsByClassName('ant-modal-body')[0]}
                 item={{ value: get(licensed, 'attribution.parties', []).map(l => ({ value: l })) }}
                 readOnly
               />

--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -196,15 +196,12 @@ class FullDetailComponent extends Component {
           <Row className="no-gutters">
             <Col md={3}>{this.renderLabel('Discovered')}</Col>
             <Col md={9} className="definition__line">
-              <p
-                className={`list-singleLine ${Contribution.classIfDifferent(
-                  definition,
-                  previewDefinition,
-                  'licensed.discovered.expressions'
-                )}`}
-              >
-                {get(licensed, 'discovered.expressions', []).join(', ')}
-              </p>
+              <CopyrightsRenderer
+                container={document.getElementsByClassName('ant-modal-body')[0]}
+                item={{ value: get(licensed, 'discovered.expressions', []).map(l => ({ value: l })) }}
+                readOnly
+                placement="right"
+              />
             </Col>
           </Row>
         </Col>

--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { Component, Fragment } from 'react'
-import { Row, Button, Col } from 'react-bootstrap'
+import { Row, Button, Col, Popover, OverlayTrigger } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import Tabs from 'antd/lib/tabs'
 import get from 'lodash/get'
@@ -14,7 +14,6 @@ import FileList from '../FileList'
 import InlineEditor from '../InlineEditor'
 import MonacoEditorWrapper from '../MonacoEditorWrapper'
 import FacetsEditor from '../FacetsEditor'
-import CopyrightsRenderer from '../CopyrightsRenderer'
 import 'antd/dist/antd.css'
 import Contribution from '../../utils/contribution'
 import Definition from '../../utils/definition'
@@ -196,12 +195,7 @@ class FullDetailComponent extends Component {
           <Row className="no-gutters">
             <Col md={3}>{this.renderLabel('Discovered')}</Col>
             <Col md={9} className="definition__line">
-              <CopyrightsRenderer
-                container={document.getElementsByClassName('ant-modal-body')[0]}
-                item={{ value: get(licensed, 'discovered.expressions', []).map(l => ({ value: l })) }}
-                readOnly
-                placement="right"
-              />
+              {this.renderPopover(licensed, 'discovered.expressions', 'Discovered')}
             </Col>
           </Row>
         </Col>
@@ -209,11 +203,7 @@ class FullDetailComponent extends Component {
           <Row className="no-gutters">
             <Col md={3}>{this.renderLabel('Attribution')}</Col>
             <Col md={9} className="definition__line">
-              <CopyrightsRenderer
-                container={document.getElementsByClassName('ant-modal-body')[0]}
-                item={{ value: get(licensed, 'attribution.parties', []).map(l => ({ value: l })) }}
-                readOnly
-              />
+              {this.renderPopover(licensed, 'attribution.parties', 'Attributions')}
             </Col>
           </Row>
           <Row className="no-gutters">
@@ -228,6 +218,33 @@ class FullDetailComponent extends Component {
           </Row>
         </Col>
       </Row>
+    )
+  }
+
+  renderPopover(licensed, key, title) {
+    const attributions = get(licensed, key, [])
+    if (!attributions) return null
+
+    return (
+      <OverlayTrigger
+        trigger="click"
+        placement="left"
+        overlay={
+          <Popover title={title}>
+            <div className="popoverRenderer popoverRenderer_scrollY">
+              {attributions.map((a, index) => (
+                <div key={`${a}_${index}`} className="popoverRenderer__items">
+                  <div className="popoverRenderer__items__value">
+                    <span>{a}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Popover>
+        }
+      >
+        <span className="popoverSpan">{attributions}</span>
+      </OverlayTrigger>
     )
   }
 

--- a/src/components/InlineEditor.js
+++ b/src/components/InlineEditor.js
@@ -56,6 +56,7 @@ export default class InlineEditor extends React.Component {
     if (!editing)
       return (
         <span
+          title={this.renderers[type](value)}
           className={`editable-field ${extraClass} ${value ? (changed ? 'bg-info' : '') : 'placeholder-text'}`}
           onClick={() => (readOnly ? null : this.setState({ editing: true }, () => onClick && onClick()))}
         >

--- a/src/components/PageDefinitions.js
+++ b/src/components/PageDefinitions.js
@@ -199,11 +199,11 @@ class PageDefinitions extends AbstractPageDefinitions {
     })
   }
 
-  onAddComponent(value, after = null) {
+  async onAddComponent(value, after = null) {
     const { dispatch, token, definitions } = this.props
     const component = typeof value === 'string' ? EntitySpec.fromPath(value) : value
     const path = component.toPath()
-    !definitions.entries[path] && dispatch(getDefinitionsAction(token, [path]))
+    !definitions.entries[path] && (await dispatch(getDefinitionsAction(token, [path])))
     dispatch(uiBrowseUpdateList({ add: component }))
   }
 

--- a/src/components/PopoverRenderer.js
+++ b/src/components/PopoverRenderer.js
@@ -63,7 +63,6 @@ class PopoverRenderer extends Component {
 
   renderRow(item, index) {
     const { editable, editorType, editorPlaceHolder, addItem, editRow } = this.props
-
     const extraClass = item.isDifferent ? 'popoverRenderer__items__value--isEdited' : ''
     return (
       item && (

--- a/src/components/PopoverRenderer.js
+++ b/src/components/PopoverRenderer.js
@@ -64,15 +64,14 @@ class PopoverRenderer extends Component {
   renderRow(item, index) {
     const { editable, editorType, editorPlaceHolder, addItem, editRow } = this.props
 
+    const extraClass = item.isDifferent ? 'popoverRenderer__items__value--isEdited' : ''
     return (
       item && (
         <div key={`${item.value}_${index}`} className="popoverRenderer__items">
-          <div
-            className={`popoverRenderer__items__value ${item.isDifferent && 'popoverRenderer__items__value--isEdited'}`}
-          >
+          <div className={`popoverRenderer__items__value ${extraClass}}`}>
             {
               <InlineEditor
-                extraClass={item.isDifferent ? 'popoverRenderer__items__value--isEdited' : ''}
+                extraClass={extraClass}
                 readOnly={!editable}
                 type={editorType}
                 initialValue={item.value || ''}
@@ -126,7 +125,7 @@ class PopoverRenderer extends Component {
   }
 
   render() {
-    const { values, showAddRow, placement, positionLeft, positionTop } = this.props
+    const { editable, values, showAddRow, placement, positionLeft, positionTop } = this.props
 
     return (
       <Popover
@@ -137,7 +136,7 @@ class PopoverRenderer extends Component {
         title={this.renderPopoverTitle()}
         bsStyle={{ width: '500px' }}
       >
-        <div className="popoverRenderer">
+        <div className={`popoverRenderer ${editable ? '' : 'popoverRenderer_scrollY'}`}>
           {showAddRow && this.renderEditRow()}
           {values && isArray(values)
             ? values.map((item, index) => this.renderRow(item, index))

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -207,3 +207,7 @@
     text-overflow: ellipsis;
   }
 }
+
+.copyrightVal {
+  cursor: pointer;
+}

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -210,4 +210,7 @@
 
 .copyrightVal {
   cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -219,3 +219,10 @@
     white-space: nowrap;
   }
 }
+
+.popoverSpan {
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -208,9 +208,14 @@
   }
 }
 
-.copyrightVal {
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.copyrightContainer {
+  display: inherit;
+  width: 100%;
+
+  span {
+    cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/src/styles/_Popover.scss
+++ b/src/styles/_Popover.scss
@@ -1,7 +1,7 @@
 .popoverRenderer {
   max-height: 200px;
   overflow-y: auto;
-  overflow-x: scroll;
+  overflow-x: auto;
   width: 100%;
 }
 .popoverRenderer__container {

--- a/src/styles/_Popover.scss
+++ b/src/styles/_Popover.scss
@@ -1,7 +1,7 @@
 .popoverRenderer {
   max-height: 200px;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: scroll;
   width: 100%;
 }
 .popoverRenderer__container {
@@ -34,4 +34,13 @@
 }
 .popoverRenderer__items__formControl {
   width: 200px;
+}
+.popoverRenderer_scrollY {
+  .list-singleLine {
+    overflow: visible;
+  }
+
+  .popoverRenderer__items__value {
+    overflow: visible;
+  }
 }

--- a/src/utils/definition.js
+++ b/src/utils/definition.js
@@ -12,7 +12,6 @@ export default class Definition {
   }
 
   static getDefinitionPreview(state) {
-    console.log(state.ui.inspect.definition)
     return !state.ui.curate.previewDefinition.isFetching
       ? Contribution.getChangesFromPreview(
           Object.assign({}, state.ui.inspect.definition.item),


### PR DESCRIPTION
Fixed issue: https://github.com/clearlydefined/website/issues/294

When you click on the **Attributions** value it shows a Popover with all the Copyrights in both the Definition and Full Details View (modal).
You can scroll horizontally and vertically.