### PR TITLE
Issue #293 - Changes to copyright info on files not displaying well in review view

### DIFF
--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -319,6 +319,9 @@ export default class DefinitionEntry extends React.Component {
 
   renderPopover(licensed, key, title) {
     const values = get(licensed, key, [])
+    // compare facets without folding
+    if (key === 'attribution.parties') key = 'licensed.facets'
+    const classIfDifferent = this.classIfDifferent(key)
     if (!values) return null
 
     return (
@@ -340,7 +343,7 @@ export default class DefinitionEntry extends React.Component {
           </Popover>
         }
       >
-        <span className="popoverSpan">{values.join(', ')}</span>
+        <span className={`popoverSpan ${classIfDifferent}`}>{values.join(', ')}</span>
       </OverlayTrigger>
     )
   }

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -133,6 +133,7 @@
 .editable-marker {
   font-size: x-small;
   padding-right: 4px;
+  cursor: pointer;
 }
 
 .editable-editor {


### PR DESCRIPTION
You can double check the fix on:
http://localhost:3000/curations/193

for https://github.com/clearlydefined/curated-data-dev/pull/193

<img width="1179" alt="clearlydefined" src="https://user-images.githubusercontent.com/899175/45825474-00246b00-bcfb-11e8-9252-831993b5e640.png">
