### PR TITLE
Issue #136 - Constrain the type of files that can be dropped

### DIFF
--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -109,11 +109,12 @@ export default class ComponentList extends React.Component {
         {scores && <img className="list-buttons" src={getBadgeUrl(scores.tool, scores.effective)} alt="score" />}
         <ButtonGroup>
           {!isSourceComponent &&
-            !readOnly && (
-              <Button className="list-hybrid-button" onClick={this.addSourceForComponent.bind(this, component)}>
-                <i className="fas fa-plus" />
-                <span>&nbsp;Add source</span>
-              </Button>
+            !readOnly &&
+            this.renderButtonWithTip(
+              <Button onClick={this.addSourceForComponent.bind(this, component)}>
+                <i className="fas fa-code" />
+              </Button>,
+              'Add the definition for source that matches this package'
             )}
           {this.renderButtonWithTip(
             <Button className="list-fa-button" onClick={this.inspectComponent.bind(this, currentComponent, definition)}>

--- a/src/components/PageDefinitions.js
+++ b/src/components/PageDefinitions.js
@@ -198,6 +198,7 @@ class PageDefinitions extends AbstractPageDefinitions {
 
   onDrop(acceptedFiles, rejectedFiles) {
     const { dispatch } = this.props
+    if (!acceptedFiles.length) return
     dispatch(uiNotificationNew({ type: 'info', message: 'Loading component list from file(s)', timeout: 5000 }))
     acceptedFiles.forEach(file => {
       const reader = new FileReader()
@@ -213,6 +214,11 @@ class PageDefinitions extends AbstractPageDefinitions {
     })
   }
 
+  onDropRejected = files => {
+    const fileNames = files.map(file => file.name).join(', ')
+    this.props.dispatch(uiNotificationNew({ type: 'danger', message: `Could not load: ${fileNames}`, timeout: 5000 }))
+  }
+
   onAddComponent(value, after = null) {
     const { dispatch, token, definitions } = this.props
     const component = typeof value === 'string' ? EntitySpec.fromPath(value) : value
@@ -223,7 +229,13 @@ class PageDefinitions extends AbstractPageDefinitions {
 
   dropZone(child) {
     return (
-      <Dropzone disableClick onDrop={this.onDrop} style={{ position: 'relative' }}>
+      <Dropzone
+        accept="application/json"
+        disableClick
+        onDrop={this.onDrop}
+        onDropRejected={this.onDropRejected}
+        style={{ position: 'relative' }}
+      >
         {child}
       </Dropzone>
     )


### PR DESCRIPTION
This will also show a notification if a wrong file(s) is dropped:
<img width="658" alt="clearlydefined" src="https://user-images.githubusercontent.com/899175/45831786-eab63d80-bd08-11e8-82b8-02d17183fa0f.png">


One note on # 136
- at the moment multiple files can be uploaded. I'm not sure if the intended behaviour