### PR TITLE
Issue #162 - High level view of definition (icon and empty component)

### DIFF
--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -123,7 +123,11 @@ export default class ComponentList extends React.Component {
             'Dig into this definition'
           )}
         </ButtonGroup>
-        {!readOnly && <i className="fas fa-times list-remove" onClick={this.removeComponent.bind(this, component)} />}
+        {!readOnly && (
+          <Button bsStyle="link" onClick={this.removeComponent.bind(this, component)}>
+            <i className="fas fa-times list-remove" />
+          </Button>
+        )}
       </div>
     )
   }

--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -104,6 +104,7 @@ export default class ComponentList extends React.Component {
     const { readOnly } = this.props
     const isSourceComponent = this.isSourceComponent(component)
     const scores = Definition.computeScores(definition)
+    const isDisabled = Definition.isDefinitionEmpty(definition)
     return (
       <div className="list-activity-area">
         {scores && <img className="list-buttons" src={getBadgeUrl(scores.tool, scores.effective)} alt="score" />}
@@ -117,7 +118,11 @@ export default class ComponentList extends React.Component {
               'Add the definition for source that matches this package'
             )}
           {this.renderButtonWithTip(
-            <Button className="list-fa-button" onClick={this.inspectComponent.bind(this, currentComponent, definition)}>
+            <Button
+              className="list-fa-button"
+              onClick={this.inspectComponent.bind(this, currentComponent, definition)}
+              disabled={isDisabled}
+            >
               <i className="fas fa-search" />
             </Button>,
             'Dig into this definition'

--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -109,11 +109,12 @@ export default class ComponentList extends React.Component {
         {scores && <img className="list-buttons" src={getBadgeUrl(scores.tool, scores.effective)} alt="score" />}
         <ButtonGroup>
           {!isSourceComponent &&
-            !readOnly && (
-              <Button className="list-hybrid-button" onClick={this.addSourceForComponent.bind(this, component)}>
-                <i className="fas fa-plus" />
-                <span>&nbsp;Add source</span>
-              </Button>
+            !readOnly &&
+            this.renderButtonWithTip(
+              <Button onClick={this.addSourceForComponent.bind(this, component)}>
+                <i className="fas fa-code" />
+              </Button>,
+              'Add the definition for source that matches this package'
             )}
           {this.renderButtonWithTip(
             <Button className="list-fa-button" onClick={this.inspectComponent.bind(this, currentComponent, definition)}>

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -12,6 +12,7 @@ import pypi from '../images/pypi.png'
 import gem from '../images/gem.png'
 import nuget from '../images/nuget.svg'
 import Contribution from '../utils/contribution'
+import Definition from '../utils/definition'
 
 export default class DefinitionEntry extends React.Component {
   static propTypes = {
@@ -365,6 +366,7 @@ export default class DefinitionEntry extends React.Component {
         message={this.renderMessage(definition)}
         buttons={renderButtons && renderButtons(definition)}
         onClick={onClick}
+        isDisabled={Definition.isDefinitionEmpty(definition)}
         panel={component.expanded ? this.renderPanel(definition) : null}
       />
     )

--- a/src/components/TwoLineEntry.js
+++ b/src/components/TwoLineEntry.js
@@ -13,7 +13,8 @@ export default class TwoLineEntry extends React.Component {
     message: PropTypes.element,
     onClick: PropTypes.func,
     panel: PropTypes.element,
-    highlight: PropTypes.bool
+    highlight: PropTypes.bool,
+    isDisabled: PropTypes.bool
   }
 
   static defaultProps = {
@@ -21,10 +22,10 @@ export default class TwoLineEntry extends React.Component {
   }
 
   render() {
-    const { buttons, image, headline, message, onClick, letter, panel, highlight } = this.props
+    const { buttons, image, headline, message, onClick, letter, panel, highlight, isDisabled } = this.props
     return (
       <div className="two-line-entry">
-        <div className="list-row" onClick={onClick}>
+        <div className={`list-row${isDisabled ? ' isDisabled' : ''}`} onClick={onClick}>
           {image && <img className={`list-image${highlight ? ' list-highlight' : ''}`} src={image} alt="" />}
           {letter && !image && <span className="list-letter">{letter.slice(0, 1)}</span>}
           <div className="list-body">
@@ -33,7 +34,7 @@ export default class TwoLineEntry extends React.Component {
           </div>
           {buttons}
         </div>
-        {panel && <div className="list-panel">{panel}</div>}
+        {!isDisabled && panel && <div className="list-panel">{panel}</div>}
       </div>
     )
   }

--- a/src/styles/_List.scss
+++ b/src/styles/_List.scss
@@ -20,9 +20,16 @@
 
   &.isDisabled,
   &.isDisabled:hover {
-    background-color: #eee;
-    color: #777;
     cursor: not-allowed;
+
+    .list-image,
+    .list-body {
+      opacity: 0.8;
+    }
+
+    .list-fa-button {
+      color: inherit;
+    }
   }
 
   .btn-link {

--- a/src/styles/_List.scss
+++ b/src/styles/_List.scss
@@ -13,14 +13,25 @@
   align-items: center;
   padding: 5px 15px 5px 10px;
   cursor: pointer;
+
+  &:hover {
+    background: $color_black_10;
+  }
+
+  &.isDisabled,
+  &.isDisabled:hover {
+    background-color: #eee;
+    color: #777;
+    cursor: not-allowed;
+  }
+
+  .btn-link {
+    padding: 0;
+  }
 }
 
 .list-highlight-text {
   color: $color_highlight;
-}
-
-.list-row:hover {
-  background: $color_black_10;
 }
 
 .list-image {

--- a/src/utils/definition.js
+++ b/src/utils/definition.js
@@ -30,4 +30,14 @@ export default class Definition {
     const effective = Math.ceil((get(definition, 'described.score', 0) + get(definition, 'licensed.score', 0)) / 2)
     return { tool, effective }
   }
+
+  /**
+   *
+   *
+   * @param {*} definition
+   * @returns {boolean}
+   */
+  static isDefinitionEmpty(definition) {
+    return definition.described && definition.described.sourceLocation === undefined
+  }
 }

--- a/src/utils/definition.js
+++ b/src/utils/definition.js
@@ -32,7 +32,7 @@ export default class Definition {
   }
 
   /**
-   *
+   * Determine if a component doesn't have any data. In order to show in the UI in the list of Components
    *
    * @param {*} definition
    * @returns {boolean}


### PR DESCRIPTION
This is how it looks 
![sep-21-2018 16-27-09](https://user-images.githubusercontent.com/899175/45884092-9324da00-bdbb-11e8-868d-b02e68f2bdb5.gif)

You can use this file [components with empty component.json](https://gist.github.com/gianpaj/0c35d3095a60fc0c235e7e711c121df8) to drag-and-drop and see a component that doesn't have data.


