### PR TITLE
Improve perf of foldFacets

### DIFF
--- a/src/utils/__tests__/contribution.test.unit.js
+++ b/src/utils/__tests__/contribution.test.unit.js
@@ -2,6 +2,18 @@ import Contribution from '../contribution'
 
 describe('Contribution', () => {
   it('returns a definition without a license', () => {
+    var t0 = performance.now()
+    for (let i = 0; i < 50000; i++) {
+      Contribution.foldFacets(definitionWithoutLicense)
+    }
+    var t1 = performance.now()
+    console.log("Call to foldFacets memoize'd took " + (t1 - t0) + ' milliseconds.')
+    var t00 = performance.now()
+    for (let i = 0; i < 50000; i++) {
+      Contribution.foldFacetsRaw(definitionWithoutLicense)
+    }
+    var t11 = performance.now()
+    console.log('Call to foldFacets raw took ' + (t11 - t00) + ' milliseconds.')
     const resultDefinition = Contribution.foldFacets(definitionWithoutLicense)
     expect(resultDefinition.licensed.declared).toBe(definitionWithoutLicense.licensed.declared)
   })


### PR DESCRIPTION
Hi @storrisi 

I remembered that the `foldFacets` functions used to some time for heavy components.

So I encountered that maybe the function can be _memoized_?

https://codeburst.io/understanding-memoization-in-3-minutes-2e58daf33a19
https://calendee.com/2018/10/21/understanding-lodash-memoize/

Making a benchmark of `50000` iterations you can see the perf improvement.

```
  console.log src/utils/__tests__/contribution.test.unit.js:10
    Call to foldFacets memoize'd took 8.958548999999948 milliseconds.

  console.log src/utils/__tests__/contribution.test.unit.js:16
    Call to foldFacets raw took 366.17099099999996 milliseconds.
```

Just a suggestion of course.